### PR TITLE
Fix error datetime format in bot's response

### DIFF
--- a/src/core/common/constant/give-away.constant.js
+++ b/src/core/common/constant/give-away.constant.js
@@ -1,3 +1,3 @@
-export const DATE_FORMAT = 'hh:mm DD/MM/YYYY';
+export const DATE_FORMAT = 'HH:mm DD/MM/YYYY';
 export const DEFAULT_SCHEDULE_TIME = '23:59';
 export const DEFAULT_TIMEZONE = 'Asia/Bangkok';

--- a/src/core/utils/response.utils.js
+++ b/src/core/utils/response.utils.js
@@ -1,7 +1,8 @@
+import { DATE_FORMAT } from 'core/common/constant';
 /**
  * @param {moment} date 
  *
  */
 export function formatDateForResponse(date) {
-    return `${date.date()}/${date.month()}/${date.year()} - ${date.hour()}:${date.minute()}:00]`;
+    return `${date.format(DATE_FORMAT).toString()}`;
 }


### PR DESCRIPTION
Sửa lỗi khi response ngày tháng năm. 
Khi xài moment, getMonth ra thì nó index từ 0 nên bị lệch 1. Đã test thử lại
![image](https://user-images.githubusercontent.com/55595623/151570948-20f629f1-70dc-44b7-a661-c05d26292fc0.png)
